### PR TITLE
Alternative syntax support

### DIFF
--- a/wast.sublime-syntax
+++ b/wast.sublime-syntax
@@ -11,8 +11,8 @@ variables:
   DECFRC: (?:{{DECNUM}})?
   DECNUM: '\d(_?\d)*'
   DROPSL: '(?:drop|select){{IDTERM}}'
-  FLOATC: 'f(?:32|64)\.(?:a(?:bs|dd)|c(?:eil|o(?:nvert_[su]/i(?:32|64)|pysign))|div|eq|floor|[gl][et]|m(?:ax|in|ul)|ne(?:arest|g)?|s(?:qrt|ub)|trunc)'
-  FLOATO: 'f32\.reinterpret/i32|f64\.(?:promote/f32|reinterpret/i64)'
+  FLOATC: 'f(?:32|64)\.(?:a(?:bs|dd)|c(?:eil|o(?:nvert_(?:(?:[su]/i(?:32|64))|(?:i(?:32|64)_[su]))|pysign))|div|eq|floor|[gl][et]|m(?:ax|in|ul)|ne(?:arest|g)?|s(?:qrt|ub)|trunc)'
+  FLOATO: 'f32\.(?:reinterpret[/_]i32|demote[/_]f64)|f64\.(?:promote[/_]f32|reinterpret[/_]i64)'
   FLOATP: '[+-]?(?:inf|nan(?::0x{{HEXNUM}})?|{{HEXFLT}}|{{DECFLT}}){{IDTERM}}'
   FLOW_1: '(?:nop|return|unreachable){{IDTERM}}'
   FLOW_2: 'br(?:_if)?{{IDTERM}}'
@@ -23,9 +23,9 @@ variables:
   IDCHAR: '[!-~&&[^"'',;{}()\[\]]]'
   IDNAME: '\${{IDCHAR}}+'
   IDTERM: '(?!{{IDCHAR}})'
-  INTERC: 'i(?:32|64)\.(?:a[dn]d|c[lt]z|div_[su]|eqz?|[gl][et]_[su]|mul|ne|or|popcnt|r(?:em_[su]|ot[lr])|s(?:h(l|r_[su])|ub)|trunc_[su]/f(?:32|64)|xor)'
+  INTERC: 'i(?:32|64)\.(?:a[dn]d|c[lt]z|div_[su]|eqz?|[gl][et]_[su]|mul|ne|or|popcnt|r(?:em_[su]|ot[lr])|s(?:h(l|r_[su])|ub)|trunc_(?:(?:[su]/f(?:32|64))|(?:f(?:32|64)_[su]))|xor)'
   INTERG: '[+-]?(?:0x{{HEXNUM}}|{{DECNUM}}){{IDTERM}}'
-  INTERO: 'i32\.(?:wrap/i64|reinterpret/f32)|i64\.(?:extend_[su]/i32|reinterpret/f64)'
+  INTERO: 'i32\.(?:wrap[/_]i64|reinterpret[/_]f32)|i64\.(?:extend_[su]/i32|reinterpret[/_]f64)'
   MEMOPS: '(?:f(?:32|64)\.(?:load|store)|i(?:32|64)\.(?:load(?:(?:8_|16_)[su])?|store(?:8|16)?)|i64\.(?:load32_[su]|store32)){{IDTERM}}'
   MEMOP2: '(memory\.(?:grow|size)|grow_memory|current_memory){{IDTERM}}'
   NCONST: '[fi](?:32|64)\.const{{IDTERM}}'
@@ -33,7 +33,7 @@ variables:
   STARTS: '(\(){{WHITES}}*(start){{IDTERM}}'
   UINTER: '(?:0x{{HEXNUM}}|{{DECNUM}}){{IDTERM}}'
   VALTYP: '[fi](?:32|64){{IDTERM}}'
-  VAROPS: '(?:[gs]et_(?:glob|loc)al|tee_local){{IDTERM}}'
+  VAROPS: '(?:[gs]et_(?:glob|loc)al|tee_local)|(?:(?:global|local)\.(?:get|set))|(?:local\.tee){{IDTERM}}'
   WHITES: '[ \n\r\t]'
 
 contexts:
@@ -455,7 +455,7 @@ contexts:
     - match: '.'
       scope: invalid.illegal.wast
   memarg:
-    - match: '(offset=)({{UINTER}})'
+    - match: '(?:(offset=)({{UINTER}}))?'
       captures:
         1: keyword.declaration.offset.wast
         2: constant.numeric.integer.wast


### PR DESCRIPTION
Support (at least partial) for the alternative syntax generated by wasm2wat (from https://github.com/WebAssembly/wabt) in no-fold mode.
Correctly highlights things like `global.set 32` and `f32.convert_i32_s`.
Does not support things like `(table 3 3 funcref)` yet.